### PR TITLE
docs: Fix README.md and add Korean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Face to Parameter
 
-This repository contains a deep learning project designed to translate human face images into a set of controllable parameters. The core idea is to create a system that can first generate a realistic face image based on a latent vector (Imitator) and then translate a given face image into that latent vector space (Translator).
+[한국어](README_ko.md)
 
-This project is structured using PyTorch and PyTorch Lightning for robust and scalable training pipelines.
+A deep learning project that translates human face images into controllable latent parameter vectors. The system first generates realistic face images from a latent vector (Imitator), then learns to translate real face images back into that latent vector space (Translator).
+
+Built with PyTorch and PyTorch Lightning.
 
 ## Architecture
 
 The project follows a two-stage training process:
 
-1.  **Imitator & Style Transfer Training**: The first stage involves training an `Imitator` model. This model is a Generator in a GAN setup, which learns to generate face images from a latent parameter vector. It is trained adversarially against a `ProjectionDiscriminator`.
-2.  **Translator Training**: The second stage trains a `Translator` model. This model takes a real face image as input and predicts the corresponding latent parameter vector that can be used by the `Imitator`. It uses a pre-trained InceptionResnetV1 for feature extraction.
+1. **Stage 1 - Imitator Training**: A conditional GAN (`Imitator` generator + `ProjectionDiscriminator`) learns to generate 512x512 face images from a 960-dimensional latent vector. Uses FiLM conditioning and EMA for stable training.
+2. **Stage 2 - Translator Training**: A `Translator` model (pre-trained InceptionResnetV1 backbone) predicts latent parameters from real face images. Uses the frozen Imitator and a style transfer model for loopback loss.
+
+**Core flow**: Face Image → Translator → Latent Vector → Imitator → Generated Face
 
 ## Getting Started
 
@@ -17,22 +21,23 @@ The project follows a two-stage training process:
 
 - Python 3.11+
 - [uv](https://github.com/astral-sh/uv) (recommended) or pip
+- CUDA 12.1 compatible GPU
 
 ### Installation
 
-1.  **Clone the repository:**
+1. **Clone the repository:**
     ```bash
-    git clone https://github.com/your-username/face_to_parameter.git
+    git clone https://github.com/kangnam7654/face_to_parameter.git
     cd face_to_parameter
     ```
 
-2.  **Create a virtual environment:**
+2. **Create a virtual environment:**
     ```bash
     python -m venv .venv
     source .venv/bin/activate
     ```
 
-3.  **Install dependencies:**
+3. **Install dependencies:**
     Using `uv` (recommended):
     ```bash
     uv pip install -r requirements.txt
@@ -41,48 +46,107 @@ The project follows a two-stage training process:
     ```bash
     pip install -r requirements.txt
     ```
-    *(Note: A `requirements.txt` file will be generated from `pyproject.toml` in the next steps.)*
 
 ## Usage
 
 ### 1. Data Preparation
 
-This project requires a dataset of face images and corresponding parameter labels. The `SimpleDatamodule` expects a CSV or Parquet file that maps image file paths to their label file paths.
-
-You will need to prepare your data accordingly, for example, by creating a `pairs.parquet` file.
-
-### 2. Training the Imitator
-
-The `train_imitator.py` script is used to train the generator and discriminator models.
+Prepare your dataset using the utility scripts:
 
 ```bash
-.venv/bin/python train_imitator.py --csv_or_parquet /path/to/your/pairs.parquet
+# Step 1: Detect and align faces
+python utils/face_align.py --root_dir /path/to/images --out_dir /path/to/aligned --resolution 512
+
+# Step 2: Generate embedding labels
+python utils/make_parameter.py --image_dir /path/to/aligned --save_dir /path/to/labels
 ```
 
-**Optional Arguments:**
+Then create a Parquet file mapping images to labels using `utils/make_pair_parquet.py`.
 
-- `--checkpoint_path`: Path to a checkpoint file to resume training. If not provided, the model starts from scratch.
-- `--lr`: Learning rate (default: `1e-3`).
-- `--batch_size`: Batch size (default: `16`).
+### 2. Training the Imitator (Stage 1)
 
-### 3. Running Tests
-
-To ensure the models and components are working correctly, you can run the unit tests.
+Train the generator and discriminator in a GAN setup:
 
 ```bash
-.venv/bin/python -m unittest discover tests
+python train_imitator.py \
+  --csv_or_parquet /path/to/pairs.parquet \
+  --iteration 1000000 \
+  --lr 1e-3 \
+  --batch_size 16 \
+  --device cuda:0
+```
+
+**Arguments:**
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--csv_or_parquet` | (required) | Path to dataset Parquet/CSV file |
+| `--checkpoint_path` | `None` | Path to checkpoint to resume training |
+| `--iteration` | `1000000` | Number of training steps |
+| `--lr` | `1e-3` | Learning rate |
+| `--batch_size` | `16` | Batch size |
+| `--device` | `mps` | Device (`cuda:0`, `mps`, `cpu`) |
+
+### 3. Training the Translator (Stage 2)
+
+Train the Translator model using pre-trained Imitator and style transfer weights:
+
+```bash
+python train.py \
+  --root_dir ./data \
+  --lr 1e-4 \
+  --resolution 256 \
+  --max_steps 10000000 \
+  --batch_size 2 \
+  --w_idt 1 \
+  --w_loop 1 \
+  --weight_imitator ./weigths/imitator.pt \
+  --weight_style_transfer ./weigths/style_transfer.pt
+```
+
+**Arguments:**
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--root_dir` | `./data` | Root directory for dataset |
+| `--lr` | `1e-4` | Learning rate |
+| `--resolution` | `256` | Input image resolution |
+| `--max_steps` | `10000000` | Maximum training steps |
+| `--batch_size` | `2` | Batch size |
+| `--w_idt` | `1` | Identity loss weight |
+| `--w_loop` | `1` | Loopback loss weight |
+| `--weight_imitator` | `None` | Pre-trained Imitator weights (`.pt`) |
+| `--weight_style_transfer` | `None` | Pre-trained style transfer weights (`.pt`) |
+
+### 4. Running Tests
+
+```bash
+python -m unittest discover tests
 ```
 
 ## Directory Structure
 
 ```
 .
-├── datamodules/      # PyTorch Lightning DataModules
-├── models/           # Model definitions (Imitator, Translator)
-├── pipelines/        # PyTorch Lightning training pipelines
-├── tests/            # Unit and integration tests
-├── utils/            # Utility scripts for data processing
-├── train_imitator.py # Training script for the Imitator model
-├── pyproject.toml    # Project dependencies
-└── README.md         # This file
+├── datamodules/          # PyTorch Dataset classes
+│   └── simple_datamodule.py
+├── models/               # Neural network architectures
+│   ├── imitator.py       # Generator (Imitator) + ProjectionDiscriminator
+│   ├── translator.py     # Face encoder (InceptionResnetV1 backbone)
+│   └── animegan.py       # AnimeGAN style transfer generator
+├── pipelines/            # PyTorch Lightning training modules
+│   ├── imitator_pipeline.py  # GAN training loop with EMA
+│   └── pipeline.py           # Translator training with loopback loss
+├── tests/                # Unit tests
+│   └── test_models.py
+├── utils/                # Data preparation utilities
+│   ├── face_align.py         # MTCNN face detection and alignment
+│   ├── make_parameter.py     # MobileNet-V3 embedding generation
+│   ├── make_pair_parquet.py  # Create image-label pair datasets
+│   ├── concat_tensor_images.py
+│   └── move_samples.py
+├── train_imitator.py     # Stage 1 training script
+├── train.py              # Stage 2 training script
+├── pyproject.toml        # Project metadata and dependencies
+└── requirements.txt      # Frozen dependency versions
 ```

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,0 +1,152 @@
+# Face to Parameter
+
+[English](README.md)
+
+사람의 얼굴 이미지를 제어 가능한 잠재 파라미터 벡터로 변환하는 딥러닝 프로젝트입니다. 잠재 벡터로부터 사실적인 얼굴 이미지를 생성(Imitator)하고, 실제 얼굴 이미지를 다시 해당 잠재 벡터 공간으로 변환(Translator)하는 시스템입니다.
+
+PyTorch와 PyTorch Lightning을 기반으로 구축되었습니다.
+
+## 아키텍처
+
+2단계 학습 과정을 따릅니다:
+
+1. **1단계 - Imitator 학습**: 조건부 GAN (`Imitator` 생성기 + `ProjectionDiscriminator`)이 960차원 잠재 벡터로부터 512x512 얼굴 이미지를 생성하도록 학습합니다. 안정적인 학습을 위해 FiLM 컨디셔닝과 EMA를 사용합니다.
+2. **2단계 - Translator 학습**: `Translator` 모델(사전 학습된 InceptionResnetV1 백본)이 실제 얼굴 이미지로부터 잠재 파라미터를 예측합니다. 동결된 Imitator와 스타일 변환 모델을 사용하여 루프백 손실을 계산합니다.
+
+**핵심 흐름**: 얼굴 이미지 → Translator → 잠재 벡터 → Imitator → 생성된 얼굴
+
+## 시작하기
+
+### 사전 요구 사항
+
+- Python 3.11+
+- [uv](https://github.com/astral-sh/uv) (권장) 또는 pip
+- CUDA 12.1 호환 GPU
+
+### 설치
+
+1. **저장소 클론:**
+    ```bash
+    git clone https://github.com/kangnam7654/face_to_parameter.git
+    cd face_to_parameter
+    ```
+
+2. **가상 환경 생성:**
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    ```
+
+3. **의존성 설치:**
+    `uv` 사용 (권장):
+    ```bash
+    uv pip install -r requirements.txt
+    ```
+    또는 `pip` 사용:
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## 사용법
+
+### 1. 데이터 준비
+
+유틸리티 스크립트를 사용하여 데이터셋을 준비합니다:
+
+```bash
+# 1단계: 얼굴 감지 및 정렬
+python utils/face_align.py --root_dir /path/to/images --out_dir /path/to/aligned --resolution 512
+
+# 2단계: 임베딩 라벨 생성
+python utils/make_parameter.py --image_dir /path/to/aligned --save_dir /path/to/labels
+```
+
+이후 `utils/make_pair_parquet.py`를 사용하여 이미지-라벨 매핑 Parquet 파일을 생성합니다.
+
+### 2. Imitator 학습 (1단계)
+
+GAN 구조로 생성기와 판별기를 학습합니다:
+
+```bash
+python train_imitator.py \
+  --csv_or_parquet /path/to/pairs.parquet \
+  --iteration 1000000 \
+  --lr 1e-3 \
+  --batch_size 16 \
+  --device cuda:0
+```
+
+**인자:**
+
+| 인자 | 기본값 | 설명 |
+|------|--------|------|
+| `--csv_or_parquet` | (필수) | 데이터셋 Parquet/CSV 파일 경로 |
+| `--checkpoint_path` | `None` | 학습 재개를 위한 체크포인트 경로 |
+| `--iteration` | `1000000` | 학습 스텝 수 |
+| `--lr` | `1e-3` | 학습률 |
+| `--batch_size` | `16` | 배치 크기 |
+| `--device` | `mps` | 디바이스 (`cuda:0`, `mps`, `cpu`) |
+
+### 3. Translator 학습 (2단계)
+
+사전 학습된 Imitator 및 스타일 변환 가중치를 사용하여 Translator 모델을 학습합니다:
+
+```bash
+python train.py \
+  --root_dir ./data \
+  --lr 1e-4 \
+  --resolution 256 \
+  --max_steps 10000000 \
+  --batch_size 2 \
+  --w_idt 1 \
+  --w_loop 1 \
+  --weight_imitator ./weigths/imitator.pt \
+  --weight_style_transfer ./weigths/style_transfer.pt
+```
+
+**인자:**
+
+| 인자 | 기본값 | 설명 |
+|------|--------|------|
+| `--root_dir` | `./data` | 데이터셋 루트 디렉토리 |
+| `--lr` | `1e-4` | 학습률 |
+| `--resolution` | `256` | 입력 이미지 해상도 |
+| `--max_steps` | `10000000` | 최대 학습 스텝 |
+| `--batch_size` | `2` | 배치 크기 |
+| `--w_idt` | `1` | Identity 손실 가중치 |
+| `--w_loop` | `1` | 루프백 손실 가중치 |
+| `--weight_imitator` | `None` | 사전 학습된 Imitator 가중치 (`.pt`) |
+| `--weight_style_transfer` | `None` | 사전 학습된 스타일 변환 가중치 (`.pt`) |
+
+### 4. 테스트 실행
+
+```bash
+python -m unittest discover tests
+```
+
+## 디렉토리 구조
+
+```
+.
+├── datamodules/          # PyTorch Dataset 클래스
+│   └── simple_datamodule.py
+├── models/               # 신경망 아키텍처
+│   ├── imitator.py       # 생성기 (Imitator) + ProjectionDiscriminator
+│   ├── translator.py     # 얼굴 인코더 (InceptionResnetV1 백본)
+│   └── animegan.py       # AnimeGAN 스타일 변환 생성기
+├── pipelines/            # PyTorch Lightning 학습 모듈
+│   ├── imitator_pipeline.py  # EMA 적용 GAN 학습 루프
+│   └── pipeline.py           # 루프백 손실을 활용한 Translator 학습
+├── tests/                # 단위 테스트
+│   └── test_models.py
+├── utils/                # 데이터 준비 유틸리티
+│   ├── face_align.py         # MTCNN 얼굴 감지 및 정렬
+│   ├── make_parameter.py     # MobileNet-V3 임베딩 생성
+│   ├── make_pair_parquet.py  # 이미지-라벨 쌍 데이터셋 생성
+│   ├── concat_tensor_images.py
+│   └── move_samples.py
+├── train_imitator.py     # 1단계 학습 스크립트
+├── train.py              # 2단계 학습 스크립트
+├── pyproject.toml        # 프로젝트 메타데이터 및 의존성
+└── requirements.txt      # 고정된 의존성 버전
+```


### PR DESCRIPTION
README.md fixes:
- Fix git clone URL (your-username → kangnam7654)
- Remove outdated note about requirements.txt generation
- Add CUDA 12.1 GPU prerequisite
- Add Stage 2 Translator training section with full argument table
- Document data preparation pipeline (face_align, make_parameter)
- Add argument table for Imitator training (--device, --iteration)
- Fix directory structure (add train.py, utils/ details, requirements.txt)
- Fix datamodules/ description (PyTorch Dataset, not LightningDataModule)
- Add Korean README link

README_ko.md:
- Full Korean translation of all sections

https://claude.ai/code/session_01LigcU8JqTiWwcscPk67wBS